### PR TITLE
Repair plugin dependency issue

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_shorts/screens/content_screen.dart';
-import 'package:flutter_swiper/flutter_swiper.dart';
+import 'package:card_swiper/card_swiper.dart';
 
 class HomePage extends StatelessWidget {
   final List<String> videos = [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  flutter_swiper: ^1.1.6
+  card_swiper: ^2.0.3
   chewie: ^1.0.0
   video_player: ^2.1.1
 


### PR DESCRIPTION
As I followed your tutorial on YouTube the flutter_swiper plugin gave me issues as it was not updated to use null safety. I used card_swiper plugin and I guess it's the same kind of plugin